### PR TITLE
External prover

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ dag_cbor = ["serde_cbor", "serde_cbor/tags"]
 multibase = { version = "1.0", git = "https://github.com/cryptidtech/rust-multibase.git" }
 multicodec = { version = "1.0", git = "https://github.com/cryptidtech/rust-multicodec.git" }
 multihash = { version = "1.0", git = "https://github.com/cryptidtech/multihash.git" }
-multikey = { version = "1.0", git = "https://github.com/cryptidtech/multikey.git" }
-multisig = { version = "1.0", git = "https://github.com/cryptidtech/multisig.git" }
+multikey = { version = "1.0", git = "https://github.com/DougAnderson444/multikey.git" }
+multisig = { version = "1.0", git = "https://github.com/DougAnderson444/multisig.git" }
 multitrait = { version = "1.0", git = "https://github.com/cryptidtech/multitrait.git" }
 multiutil = { version = "1.0", git = "https://github.com/cryptidtech/multiutil.git" }
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ dag_cbor = ["serde_cbor", "serde_cbor/tags"]
 multibase = { version = "1.0", git = "https://github.com/cryptidtech/rust-multibase.git" }
 multicodec = { version = "1.0", git = "https://github.com/cryptidtech/rust-multicodec.git" }
 multihash = { version = "1.0", git = "https://github.com/cryptidtech/multihash.git" }
-multikey = { version = "1.0", git = "https://github.com/DougAnderson444/multikey.git" }
-multisig = { version = "1.0", git = "https://github.com/DougAnderson444/multisig.git" }
+multikey = { version = "1.0", git = "https://github.com/cryptidtech/multikey.git" }
+multisig = { version = "1.0", git = "https://github.com/cryptidtech/multisig.git" }
 multitrait = { version = "1.0", git = "https://github.com/cryptidtech/multitrait.git" }
 multiutil = { version = "1.0", git = "https://github.com/cryptidtech/multiutil.git" }
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,15 @@ dag_cbor = ["serde_cbor", "serde_cbor/tags"]
 multibase = { version = "1.0", git = "https://github.com/cryptidtech/rust-multibase.git" }
 multicodec = { version = "1.0", git = "https://github.com/cryptidtech/rust-multicodec.git" }
 multihash = { version = "1.0", git = "https://github.com/cryptidtech/multihash.git" }
-multikey = { version = "1.0", git = "https://github.com/cryptidtech/multikey.git" }
-multisig = { version = "1.0", git = "https://github.com/cryptidtech/multisig.git" }
+multikey = { version = "1.0", git = "https://github.com/DougAnderson444/multikey.git" }
+multisig = { version = "1.0", git = "https://github.com/DougAnderson444/multisig.git" }
 multitrait = { version = "1.0", git = "https://github.com/cryptidtech/multitrait.git" }
 multiutil = { version = "1.0", git = "https://github.com/cryptidtech/multiutil.git" }
 rand = "0.8"
-serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }
+serde = { version = "1.0", default-features = false, features = [
+  "alloc",
+  "derive",
+], optional = true }
 serde_cbor = { version = "0.11", optional = true }
 thiserror = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multicid"
-version = "1.0.5"
+version = "1.1.0"
 edition = "2021"
 authors = ["Dave Grantham <dwg@linuxprogrammer.org>"]
 description = "Multicodec compatible content identifier implementation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,7 @@ default = ["serde"]
 dag_cbor = ["serde_cbor", "serde_cbor/tags"]
 
 [dependencies]
-multibase = { version = "1.0", git = "https://github.com/cryptidtech/rust-multibase.git" }
-multicodec = { version = "1.0", git = "https://github.com/cryptidtech/rust-multicodec.git" }
-multihash = { version = "1.0", git = "https://github.com/DougAnderson444/multihash.git", branch = "hash-impl" }
 multikey = { version = "1.0", git = "https://github.com/DougAnderson444/multikey.git", branch = "deps" }
-multisig = { version = "1.0", git = "https://github.com/DougAnderson444/multisig.git" }
-multitrait = { version = "1.0", git = "https://github.com/cryptidtech/multitrait.git" }
-multiutil = { version = "1.0", git = "https://github.com/cryptidtech/multiutil.git" }
 rand = "0.8"
 serde = { version = "1.0", default-features = false, features = [
   "alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ dag_cbor = ["serde_cbor", "serde_cbor/tags"]
 multibase = { version = "1.0", git = "https://github.com/cryptidtech/rust-multibase.git" }
 multicodec = { version = "1.0", git = "https://github.com/cryptidtech/rust-multicodec.git" }
 multihash = { version = "1.0", git = "https://github.com/DougAnderson444/multihash.git", branch = "hash-impl" }
-multikey = { version = "1.0", git = "https://github.com/DougAnderson444/multikey.git" }
+multikey = { version = "1.0", git = "https://github.com/DougAnderson444/multikey.git", branch = "deps" }
 multisig = { version = "1.0", git = "https://github.com/DougAnderson444/multisig.git" }
 multitrait = { version = "1.0", git = "https://github.com/cryptidtech/multitrait.git" }
 multiutil = { version = "1.0", git = "https://github.com/cryptidtech/multiutil.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ dag_cbor = ["serde_cbor", "serde_cbor/tags"]
 [dependencies]
 multibase = { version = "1.0", git = "https://github.com/cryptidtech/rust-multibase.git" }
 multicodec = { version = "1.0", git = "https://github.com/cryptidtech/rust-multicodec.git" }
-multihash = { version = "1.0", git = "https://github.com/cryptidtech/multihash.git" }
+multihash = { version = "1.0", git = "https://github.com/DougAnderson444/multihash.git", branch = "hash-impl" }
 multikey = { version = "1.0", git = "https://github.com/DougAnderson444/multikey.git" }
 multisig = { version = "1.0", git = "https://github.com/DougAnderson444/multisig.git" }
 multitrait = { version = "1.0", git = "https://github.com/cryptidtech/multitrait.git" }

--- a/src/cid.rs
+++ b/src/cid.rs
@@ -18,7 +18,7 @@ pub type LegacyEncodedCid = BaseEncoded<Cid, Base58Encoder>;
 pub type EncodedCid = BaseEncoded<Cid, DetectedEncoder>;
 
 /// implementation of cid
-#[derive(Clone, Eq, Ord, PartialOrd, PartialEq)]
+#[derive(Clone, Eq, Ord, PartialOrd, PartialEq, Hash)]
 pub struct Cid {
     /// the version of the Cid
     pub(crate) codec: Codec,

--- a/src/cid.rs
+++ b/src/cid.rs
@@ -404,4 +404,20 @@ mod tests {
         assert!(cid1 != cid2);
         assert!(!cid2.is_null());
     }
+
+    #[test]
+    fn test_string_roundtrip() {
+        let v1 = Builder::new(Codec::Cidv1)
+            .with_target_codec(Codec::DagCbor)
+            .with_hash(
+                &mh::Builder::new_from_bytes(Codec::Sha3512, b"for great justice, move every zig!")
+                    .unwrap()
+                    .try_build()
+                    .unwrap(),
+            )
+            .try_build()
+            .unwrap();
+        let s = v1.to_string();
+        assert_eq!(s, EncodedCid::try_from(s.as_str()).unwrap().to_string());
+    }
 }

--- a/src/cid.rs
+++ b/src/cid.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Idnetifier: Apache-2.0
+use super::*;
 use crate::{error::CidError, Error};
 use core::fmt;
 use multibase::Base;

--- a/src/cid.rs
+++ b/src/cid.rs
@@ -156,6 +156,13 @@ impl fmt::Debug for Cid {
     }
 }
 
+impl fmt::Display for Cid {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let encoded = EncodedCid::new(self.encoding(), self.clone());
+        write!(f, "{}", encoded)
+    }
+}
+
 /// Hash builder that takes the codec and the data and produces a Multihash
 #[derive(Clone, Debug, Default)]
 pub struct Builder {
@@ -210,8 +217,7 @@ impl Builder {
             return Err(CidError::LegacyCid.into());
         }
         Ok(EncodedCid::new(
-            self.base_encoding
-                .unwrap_or_else(Cid::preferred_encoding),
+            self.base_encoding.unwrap_or_else(Cid::preferred_encoding),
             self.try_build()?,
         ))
     }
@@ -275,17 +281,23 @@ mod tests {
         assert_eq!(Codec::Sha2256, v0_1.hash.codec());
 
         // this does not assume a multibase encoded CID
-        let v0_2 = EncodedCid::try_from("bafybeihcrr5owouhnms63areolshu2lp4jjbjqlhf4exegk7tnso5ja6py").unwrap();
+        let v0_2 =
+            EncodedCid::try_from("bafybeihcrr5owouhnms63areolshu2lp4jjbjqlhf4exegk7tnso5ja6py")
+                .unwrap();
         assert_eq!(Codec::Cidv1, v0_2.codec());
         assert_eq!(Codec::DagPb, v0_2.target_codec);
         assert_eq!(Codec::Sha2256, v0_2.hash.codec());
 
-        let v0_3 = EncodedCid::try_from("f01701220e28c7aeb3a876b25ed822472e47a696fe25214c1672f0972195f9b64eea41e7e").unwrap();
+        let v0_3 = EncodedCid::try_from(
+            "f01701220e28c7aeb3a876b25ed822472e47a696fe25214c1672f0972195f9b64eea41e7e",
+        )
+        .unwrap();
         assert_eq!(Codec::Cidv1, v0_3.codec());
         assert_eq!(Codec::DagPb, v0_3.target_codec);
         assert_eq!(Codec::Sha2256, v0_3.hash.codec());
 
-        let v0_4 = EncodedCid::try_from("uAXASIOKMeus6h2sl7YIkcuR6aW_iUhTBZy8Jchlfm2TupB5-").unwrap();
+        let v0_4 =
+            EncodedCid::try_from("uAXASIOKMeus6h2sl7YIkcuR6aW_iUhTBZy8Jchlfm2TupB5-").unwrap();
         assert_eq!(Codec::Cidv1, v0_4.codec());
         assert_eq!(Codec::DagPb, v0_4.target_codec);
         assert_eq!(Codec::Sha2256, v0_4.hash.codec());

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Idnetifier: Apache-2.0
+use super::*;
 
 /// Errors created by this library
 #[derive(Clone, Debug, thiserror::Error)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,5 +35,6 @@ pub mod prelude {
 }
 
 // Re-export all multi* crates to avoid dependency conflicts
+pub use multikey;
 pub use multikey::multicrates;
 pub use multikey::multicrates::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,5 +35,5 @@ pub mod prelude {
 }
 
 // Re-export all multi* crates to avoid dependency conflicts
-//pub use multicrates::{multibase, multicodec, multihash, multisig, multitrait, multiutil};
+pub use multikey::multicrates;
 pub use multikey::multicrates::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,3 +33,7 @@ pub mod prelude {
     pub use multicodec::Codec;
     pub use multiutil::BaseEncoded;
 }
+
+// Re-export all multi* crates to avoid dependency conflicts
+//pub use multicrates::{multibase, multicodec, multihash, multisig, multitrait, multiutil};
+pub use multikey::multicrates::*;

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Idnetifier: Apache-2.0
+use super::{multicodec, multihash};
 use crate::{vlad, Cid, Vlad};
+
 use core::fmt;
 use multicodec::Codec;
 use multihash::Multihash;
-use multikey::Nonce;
 #[cfg(feature = "dag_cbor")]
-use multitrait::TryDecodeFrom;
+use multikey::multicrates::multitrait::TryDecodeFrom;
+use multikey::Nonce;
 use serde::{
     de::{Error, MapAccess, Visitor},
     Deserialize, Deserializer,

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -47,17 +47,25 @@ mod tests {
         assert_tokens(
             &v0.readable(),
             &[
-                Token::Struct { name: "cid", len: 3, },
+                Token::Struct {
+                    name: "cid",
+                    len: 3,
+                },
                 Token::BorrowedStr("version"),
                 Token::U64(0),
                 Token::BorrowedStr("encoding"),
                 Token::BorrowedStr("dag-pb"),
                 Token::BorrowedStr("hash"),
-                Token::Struct { name: "multihash", len: 2, },
+                Token::Struct {
+                    name: "multihash",
+                    len: 2,
+                },
                 Token::BorrowedStr("codec"),
                 Token::BorrowedStr("sha2-256"),
                 Token::BorrowedStr("hash"),
-                Token::BorrowedStr("f20e28c7aeb3a876b25ed822472e47a696fe25214c1672f0972195f9b64eea41e7e"),
+                Token::BorrowedStr(
+                    "f20e28c7aeb3a876b25ed822472e47a696fe25214c1672f0972195f9b64eea41e7e",
+                ),
                 Token::StructEnd,
                 Token::StructEnd,
             ],
@@ -253,7 +261,7 @@ mod tests {
         let vlad = vlad::Builder::default()
             .with_nonce(&nonce)
             .with_cid(&cid)
-            .try_build_encoded()
+            .try_build_encoded(|cid| Ok(cid.clone().into()))
             .unwrap();
 
         assert_tokens(
@@ -284,7 +292,7 @@ mod tests {
         let vlad = vlad::Builder::default()
             .with_nonce(&nonce)
             .with_cid(&cid)
-            .try_build()
+            .try_build(|cid| Ok(cid.clone().into()))
             .unwrap();
 
         assert_tokens(
@@ -347,7 +355,7 @@ mod tests {
         let vlad = vlad::Builder::default()
             .with_nonce(&nonce)
             .with_cid(&cid)
-            .try_build()
+            .try_build(|cid| Ok(cid.clone().into()))
             .unwrap();
 
         let s = serde_json::to_string(&vlad).unwrap();
@@ -377,7 +385,7 @@ mod tests {
         let vlad = vlad::Builder::default()
             .with_nonce(&nonce)
             .with_cid(&cid)
-            .try_build()
+            .try_build(|cid| Ok(cid.clone().into()))
             .unwrap();
 
         let v = serde_cbor::to_vec(&vlad).unwrap();
@@ -408,7 +416,7 @@ mod tests {
         let vlad = vlad::Builder::default()
             .with_nonce(&nonce)
             .with_cid(&cid)
-            .try_build()
+            .try_build(|cid| Ok(cid.clone().into()))
             .unwrap();
 
         let v = serde_cbor::to_vec(&vlad).unwrap();
@@ -420,12 +428,7 @@ mod tests {
     #[test]
     fn test_null_cid_serde_compact() {
         let c = cid::Cid::null();
-        assert_tokens(
-            &c.compact(),
-            &[
-                Token::BorrowedBytes(&[1, 0, 0, 0])
-            ]
-        );
+        assert_tokens(&c.compact(), &[Token::BorrowedBytes(&[1, 0, 0, 0])]);
     }
 
     #[test]
@@ -434,32 +437,33 @@ mod tests {
         assert_tokens(
             &c.readable(),
             &[
-                Token::Struct { name: "cid", len: 3, },
+                Token::Struct {
+                    name: "cid",
+                    len: 3,
+                },
                 Token::BorrowedStr("version"),
                 Token::U64(1),
                 Token::BorrowedStr("encoding"),
                 Token::BorrowedStr("identity"),
                 Token::BorrowedStr("hash"),
-                Token::Struct { name: "multihash", len: 2, },
+                Token::Struct {
+                    name: "multihash",
+                    len: 2,
+                },
                 Token::BorrowedStr("codec"),
                 Token::BorrowedStr("identity"),
                 Token::BorrowedStr("hash"),
                 Token::BorrowedStr("f00"),
                 Token::StructEnd,
                 Token::StructEnd,
-            ]
+            ],
         );
     }
 
     #[test]
     fn test_encoded_null_cid_serde_readable() {
         let c: cid::EncodedCid = cid::Cid::null().into();
-        assert_tokens(
-            &c.readable(),
-            &[
-                Token::BorrowedStr("z2UzHM"),
-            ]
-        );
+        assert_tokens(&c.readable(), &[Token::BorrowedStr("z2UzHM")]);
     }
 
     #[test]
@@ -467,9 +471,7 @@ mod tests {
         let v = vlad::Vlad::null();
         assert_tokens(
             &v.compact(),
-            &[
-                Token::BorrowedBytes(&[135, 36, 187, 36, 0, 1, 0, 0, 0]),
-            ]
+            &[Token::BorrowedBytes(&[135, 36, 187, 36, 0, 1, 0, 0, 0])],
         );
     }
 
@@ -479,20 +481,32 @@ mod tests {
         assert_tokens(
             &v.readable(),
             &[
-                Token::Struct { name: "vlad", len: 2, },
+                Token::Struct {
+                    name: "vlad",
+                    len: 2,
+                },
                 Token::BorrowedStr("nonce"),
-                Token::Struct { name: "nonce", len: 1, },
+                Token::Struct {
+                    name: "nonce",
+                    len: 1,
+                },
                 Token::BorrowedStr("nonce"),
                 Token::BorrowedStr("f00"),
                 Token::StructEnd,
                 Token::BorrowedStr("cid"),
-                Token::Struct { name: "cid", len: 3, },
+                Token::Struct {
+                    name: "cid",
+                    len: 3,
+                },
                 Token::BorrowedStr("version"),
                 Token::U64(1),
                 Token::BorrowedStr("encoding"),
                 Token::BorrowedStr("identity"),
                 Token::BorrowedStr("hash"),
-                Token::Struct { name: "multihash", len: 2, },
+                Token::Struct {
+                    name: "multihash",
+                    len: 2,
+                },
                 Token::BorrowedStr("codec"),
                 Token::BorrowedStr("identity"),
                 Token::BorrowedStr("hash"),
@@ -500,18 +514,13 @@ mod tests {
                 Token::StructEnd,
                 Token::StructEnd,
                 Token::StructEnd,
-            ]
+            ],
         );
     }
 
     #[test]
     fn test_encoded_null_vlad_serde_readable() {
         let v: vlad::EncodedVlad = vlad::Vlad::null().into();
-        assert_tokens(
-            &v.readable(),
-            &[
-                Token::BorrowedStr("bq4slwjaaaeaaaaa"),
-            ]
-        );
+        assert_tokens(&v.readable(), &[Token::BorrowedStr("bq4slwjaaaeaaaaa")]);
     }
 }

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -3,9 +3,15 @@
 mod de;
 mod ser;
 
+use super::*;
+
 #[cfg(test)]
 mod tests {
-    use crate::{cid, vlad};
+    use super::*;
+    use crate::{
+        cid::{self, Cid, EncodedCid},
+        vlad::{self, EncodedVlad, Vlad},
+    };
     use multicodec::Codec;
     use multihash::mh;
     use multikey::nonce;
@@ -427,13 +433,13 @@ mod tests {
 
     #[test]
     fn test_null_cid_serde_compact() {
-        let c = cid::Cid::null();
+        let c = Cid::null();
         assert_tokens(&c.compact(), &[Token::BorrowedBytes(&[1, 0, 0, 0])]);
     }
 
     #[test]
     fn test_null_cid_serde_readable() {
-        let c = cid::Cid::null();
+        let c = Cid::null();
         assert_tokens(
             &c.readable(),
             &[
@@ -462,13 +468,13 @@ mod tests {
 
     #[test]
     fn test_encoded_null_cid_serde_readable() {
-        let c: cid::EncodedCid = cid::Cid::null().into();
+        let c: EncodedCid = Cid::null().into();
         assert_tokens(&c.readable(), &[Token::BorrowedStr("z2UzHM")]);
     }
 
     #[test]
     fn test_null_vlad_serde_compact() {
-        let v = vlad::Vlad::null();
+        let v = Vlad::null();
         assert_tokens(
             &v.compact(),
             &[Token::BorrowedBytes(&[135, 36, 187, 36, 0, 1, 0, 0, 0])],
@@ -477,7 +483,7 @@ mod tests {
 
     #[test]
     fn test_null_vlad_serde_readable() {
-        let v = vlad::Vlad::null();
+        let v = Vlad::null();
         assert_tokens(
             &v.readable(),
             &[
@@ -520,7 +526,7 @@ mod tests {
 
     #[test]
     fn test_encoded_null_vlad_serde_readable() {
-        let v: vlad::EncodedVlad = vlad::Vlad::null().into();
+        let v: EncodedVlad = Vlad::null().into();
         assert_tokens(&v.readable(), &[Token::BorrowedStr("bq4slwjaaaeaaaaa")]);
     }
 }

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -17,6 +17,7 @@ impl ser::Serialize for Cid {
         } else {
             #[cfg(feature = "dag_cbor")]
             {
+                use multicodec::Codec;
                 // build the byte string for DAG-CBOR according to the spec
                 // https://github.com/ipld/specs/blob/master/block-layer/codecs/dag-cbor.md#links
                 let mut v = Vec::new();

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -17,8 +17,8 @@ impl ser::Serialize for Cid {
         } else {
             #[cfg(feature = "dag_cbor")]
             {
-                use multicodec::Codec;
-              
+                use multikey::multicrates::multicodec::Codec;
+
                 // build the byte string for DAG-CBOR according to the spec
                 // https://github.com/ipld/specs/blob/master/block-layer/codecs/dag-cbor.md#links
                 let mut v = Vec::new();

--- a/src/vlad.rs
+++ b/src/vlad.rs
@@ -134,7 +134,6 @@ impl fmt::Debug for Vlad {
 #[derive(Clone, Debug, Default)]
 pub struct Builder {
     nonce: Option<Nonce>,
-    mk: Option<Multikey>,
     cid: Option<Cid>,
     base_encoding: Option<Base>,
 }
@@ -152,12 +151,6 @@ impl Builder {
         self
     }
 
-    /// set the signing key to generate a signature nonce
-    pub fn with_signing_key(mut self, mk: &Multikey) -> Self {
-        self.mk = Some(mk.clone());
-        self
-    }
-
     /// set the base encoding codec
     pub fn with_base_encoding(mut self, base: Base) -> Self {
         self.base_encoding = Some(base);
@@ -165,33 +158,33 @@ impl Builder {
     }
 
     /// build a base encoded vlad
-    pub fn try_build_encoded(&self) -> Result<EncodedVlad, Error> {
+    pub fn try_build_encoded(
+        &self,
+        gen_proof: impl FnMut(&Cid) -> Result<Vec<u8>, Error>,
+    ) -> Result<EncodedVlad, Error> {
         Ok(EncodedVlad::new(
-            self.base_encoding
-                .unwrap_or_else(Vlad::preferred_encoding),
-            self.try_build()?,
+            self.base_encoding.unwrap_or_else(Vlad::preferred_encoding),
+            self.try_build(gen_proof)?,
         ))
     }
 
     /// build the vlad
-    pub fn try_build(&self) -> Result<Vlad, Error> {
+    pub fn try_build(
+        &self,
+        mut gen_proof: impl FnMut(&Cid) -> Result<Vec<u8>, Error>,
+    ) -> Result<Vlad, Error> {
         let cid = self.cid.clone().ok_or(VladError::MissingCid)?;
         match &self.nonce {
             Some(nonce) => Ok(Vlad {
                 nonce: nonce.clone(),
                 cid,
             }),
-            None => match &self.mk {
-                Some(mk) => {
-                    let sv = mk.sign_view()?;
-                    let cidv: Vec<u8> = cid.clone().into();
-                    let ms = sv.sign(&cidv, false, None)?;
-                    let msv: Vec<u8> = ms.clone().into();
-                    let nonce = nonce::Builder::new_from_bytes(&msv).try_build()?;
-                    Ok(Vlad { nonce, cid })
-                }
-                None => Err(VladError::MissingNonce.into()),
-            },
+            None => {
+                let msv = gen_proof(&cid)?;
+                let nonce = nonce::Builder::new_from_bytes(&msv).try_build()?;
+
+                Ok(Vlad { nonce, cid })
+            }
         }
     }
 }
@@ -207,7 +200,7 @@ mod tests {
     #[test]
     fn test_default() {
         // build a nonce
-        let mut rng = rand::rngs::OsRng::default();
+        let mut rng = rand::rngs::OsRng;
         let nonce = nonce::Builder::new_from_random_bytes(32, &mut rng)
             .try_build()
             .unwrap();
@@ -227,7 +220,11 @@ mod tests {
         let vlad = Builder::default()
             .with_nonce(&nonce)
             .with_cid(&cid)
-            .try_build()
+            .try_build(|cid| {
+                // sign those bytes
+                let v: Vec<u8> = cid.clone().into();
+                Ok(v)
+            })
             .unwrap();
 
         assert_eq!(Codec::Vlad, vlad.codec());
@@ -236,7 +233,7 @@ mod tests {
     #[test]
     fn test_binary_roundtrip() {
         // build a nonce
-        let mut rng = rand::rngs::OsRng::default();
+        let mut rng = rand::rngs::OsRng;
         let nonce = nonce::Builder::new_from_random_bytes(32, &mut rng)
             .try_build()
             .unwrap();
@@ -256,7 +253,11 @@ mod tests {
         let vlad = Builder::default()
             .with_nonce(&nonce)
             .with_cid(&cid)
-            .try_build()
+            .try_build(|cid| {
+                // sign those bytes
+                let v: Vec<u8> = cid.clone().into();
+                Ok(v)
+            })
             .unwrap();
 
         let v: Vec<u8> = vlad.clone().into();
@@ -267,7 +268,7 @@ mod tests {
     #[test]
     fn test_encoded_roundtrip() {
         // build a nonce
-        let mut rng = rand::rngs::OsRng::default();
+        let mut rng = rand::rngs::OsRng;
         let nonce = nonce::Builder::new_from_random_bytes(32, &mut rng)
             .try_build()
             .unwrap();
@@ -287,7 +288,11 @@ mod tests {
         let vlad = Builder::default()
             .with_nonce(&nonce)
             .with_cid(&cid)
-            .try_build_encoded()
+            .try_build_encoded(|cid| {
+                // sign those bytes
+                let v: Vec<u8> = cid.clone().into();
+                Ok(v)
+            })
             .unwrap();
 
         let s = vlad.to_string();
@@ -298,7 +303,7 @@ mod tests {
     #[test]
     fn test_encodings_roundtrip() {
         // build a nonce
-        let mut rng = rand::rngs::OsRng::default();
+        let mut rng = rand::rngs::OsRng;
         let nonce = nonce::Builder::new_from_random_bytes(32, &mut rng)
             .try_build()
             .unwrap();
@@ -316,15 +321,19 @@ mod tests {
             .unwrap();
 
         // start at Identity so we skip it
-        let mut itr: BaseIter = Base::Identity.into();
+        let itr: BaseIter = Base::Identity.into();
 
-        while let Some(encoding) = itr.next() {
+        for encoding in itr {
             //print!("{}...", base_name(encoding));
             let vlad = Builder::default()
                 .with_nonce(&nonce)
                 .with_cid(&cid)
                 .with_base_encoding(encoding)
-                .try_build_encoded()
+                .try_build_encoded(|cid| {
+                    // sign those bytes
+                    let v: Vec<u8> = cid.clone().into();
+                    Ok(v)
+                })
                 .unwrap();
 
             let s = vlad.to_string();
@@ -382,14 +391,20 @@ mod tests {
         let mk = EncodedMultikey::try_from(s).unwrap();
 
         let vlad = Builder::default()
-            .with_signing_key(&mk)
             .with_cid(&cid)
             .with_base_encoding(Base::Base32Z)
-            .try_build_encoded()
+            .try_build_encoded(|cid| {
+                // use mk to sign those cid bytes
+                let signing_view = mk.sign_view()?;
+                let cidv: Vec<u8> = cid.clone().into();
+                let ms = signing_view.sign(&cidv, false, None)?;
+                let msv: Vec<u8> = ms.clone().into();
+                Ok(msv)
+            })
             .unwrap();
 
         // make sure the signature checks out
-        assert_eq!((), vlad.verify(&mk).unwrap());
+        assert!(vlad.verify(&mk).is_ok());
         let s = vlad.to_string();
         //println!("BASE32Z ({}) {}", s.len(), s);
         let de = EncodedVlad::try_from(s.as_str()).unwrap();

--- a/src/vlad.rs
+++ b/src/vlad.rs
@@ -52,6 +52,13 @@ impl Vlad {
         vv.verify(&ms, Some(&cidv))?;
         Ok(())
     }
+
+    /// Return the Vlad's [Cid].
+    /// This is the content address of the verification function.
+    /// It should match the `vlad/cid` field in a Provenance Log's first Entry.
+    pub fn cid(&self) -> &Cid {
+        &self.cid
+    }
 }
 
 impl CodecInfo for Vlad {

--- a/src/vlad.rs
+++ b/src/vlad.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Idnetifier: Apache-2.0
+use super::*;
 use crate::{error::VladError, Cid, Error};
+
 use core::fmt;
 use multibase::Base;
 use multicodec::Codec;


### PR DESCRIPTION
This PR introduces an external prover:

- [x] minor version bump to 1.1.0 due to breaking change
- [x] remove passing in the owned key
- [x] method `try_build()` now takes a user defined closure to take the cid and generate proof bytes

```rust
pub fn try_build(
        &self,
        mut gen_proof: impl FnMut(&Cid) -> Result<Vec<u8>, Error>,
    ) -> Result<Vlad, Error>
```
Fixes: https://github.com/cryptidtech/multicid/issues/2 